### PR TITLE
Fix javax.crypto.AEADBadTagException Crash by Adding a Secret Key String Resource

### DIFF
--- a/codelab-00/app/src/main/res/values/strings.xml
+++ b/codelab-00/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
   -->
 <resources>
     <string name="app_name">Biometric Login Sample</string>
+    <string name="secret_key_name">biometric_sample_encryption_key</string>
     <string name="username_hint">phone number, email, or username</string>
     <string name="invalid_username">Not a valid username</string>
     <string name="invalid_password">Password must be >5 characters</string>


### PR DESCRIPTION
This PR addresses https://github.com/googlecodelabs/biometric-login/issues/2 by providing the correct string resource to `secretKeyName` introduced in [section 01](https://developer.android.com/codelabs/biometric-login?hl=en&continue=https%3A%2F%2Fcodelabs.developers.google.com%2F#2) of the code lab.

Otherwise, the app will crash on decryption with `javax.crypto.AEADBadTagException`.